### PR TITLE
Fixed compilation using the -Werror flag

### DIFF
--- a/src/lthread_compute.c
+++ b/src/lthread_compute.c
@@ -254,7 +254,6 @@ _lthread_compute_run(void *arg)
     lthread_t *lt = NULL;
     struct timespec timeout;
     int status = 0;
-    int ret = 0;
 
     pthread_once(&key_once, once_routine);
 
@@ -296,7 +295,7 @@ _lthread_compute_run(void *arg)
             pthread_mutex_unlock(&lt->sched->compute_mutex);
 
             /* signal the prev scheduler in case it was sleeping in a poll */
-            ret = write(lt->sched->compute_pipes[1], "1", 1);
+            write(lt->sched->compute_pipes[1], "1", 1);
         }
 
         pthread_mutex_lock(&compute_sched->run_mutex);

--- a/src/lthread_sched.c
+++ b/src/lthread_sched.c
@@ -94,7 +94,6 @@ lthread_run(void)
     lthread_t *lt = NULL, *lttmp = NULL;
     int p = 0;
     int fd = 0;
-    int ret = 0;
 
     sched = lthread_get_sched();
 
@@ -140,7 +139,7 @@ lthread_run(void)
              */ 
             fd = get_fd(&sched->eventlist[p]);
             if (fd == sched->compute_pipes[0]) {
-                ret = read(fd, &tmp, sizeof(tmp));
+                read(fd, &tmp, sizeof(tmp));
                 continue;
             }
 


### PR DESCRIPTION
lthread_compute.c and lthread_sched.c had unused 'ret' variables in certain functions that cause compilation to fail with the GCC -Werror flag. My commit rectifies this.
