### PR TITLE
Ignore additional files from cmake and make

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,9 @@ Makefile.in
 missing
 src/.deps
 src/.libs
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+install_manifest.txt
+liblthread.a
+


### PR DESCRIPTION
Hi Hasan,

I just noticed that a few files were being left around when building lthread for http-openmix.

Jacob
