### PR TITLE
Build errors due to -Werror=format

### DIFF
--- a/src/lthread_sched.c
+++ b/src/lthread_sched.c
@@ -296,7 +296,7 @@ _lthread_sched_event(struct lthread *lt, int fd, enum lthread_event e,
     struct lthread *lt_tmp = NULL;
     enum lthread_st st;
     if (lt->state & BIT(LT_ST_WAIT_READ) || lt->state & BIT(LT_ST_WAIT_WRITE)) {
-        printf("Unexpected event. lt id %"PRIu64" fd %ld already in %d state\n",
+        printf("Unexpected event. lt id %"PRIu64" fd %"PRId64" already in %"PRId32" state\n",
             lt->id, lt->fd_wait, lt->state);
         assert(0);
     }


### PR DESCRIPTION
..
[ 33%] Building C object CMakeFiles/lthread.dir/src/lthread_sched.c.o
/tmp/lthread/src/lthread_sched.c: In function '_lthread_sched_event':
/tmp/lthread/src/lthread_sched.c:300:13: error: format '%ld' expects argument of type 'long int', but argument 3 has type 'int64_t' [-Werror=format]
cc1: all warnings being treated as errors
..

Fixed by using proper macros from inttypes.h for all printf format identifiers.
