### PR TITLE
lthread_socket.c: Fixed lthread_close()

### DIFF
--- a/src/lthread_socket.c
+++ b/src/lthread_socket.c
@@ -211,6 +211,12 @@ lthread_close(int fd)
         lt->state |= BIT(LT_ST_FDEOF);
     }
 
+    /* clear the eof bit of the calling lthread */
+    lt = lthread_get_sched()->current_lthread;
+    if (lt->state & BIT(LT_ST_FDEOF)) {
+        lt->state &= CLEARBIT(LT_ST_FDEOF);
+    }
+
     /* closing fd removes its registered events from poller */ 
     return (close(fd));
 }


### PR DESCRIPTION
Clear EOF bit for the calling thread if it is set
