### PR TITLE
Added public interfaces for better application integration.

### DIFF
--- a/src/lthread.c
+++ b/src/lthread.c
@@ -461,6 +461,13 @@ _lthread_renice(struct lthread *lt)
 }
 
 void
+lthread_renice()
+{
+    struct lthread *lt = lthread_get_sched()->current_lthread;
+    _lthread_renice(lt);
+}
+
+void
 lthread_wakeup(struct lthread *lt)
 {
     if (lt->state & BIT(LT_ST_SLEEPING)) {
@@ -549,4 +556,18 @@ lthread_print_timestamp(char *msg)
 	struct timeval t1 = {0, 0};
     gettimeofday(&t1, NULL);
 	printf("lt timestamp: sec: %ld usec: %ld (%s)\n", t1.tv_sec, (long) t1.tv_usec, msg);
+}
+
+int
+lthread_is_lthread_context()
+{
+    assert(pthread_once(&key_once, _lthread_key_create) == 0);
+    struct lthread_sched* sched = lthread_get_sched();
+    return (NULL != sched && NULL != sched->current_lthread);
+}
+
+int
+lthread_is_eventfd(int fd)
+{
+    return (fd == lthread_get_sched()->eventfd);
 }

--- a/src/lthread.h
+++ b/src/lthread.h
@@ -60,6 +60,7 @@ void    lthread_detach2(lthread_t *lt);
 void    lthread_exit(void *ptr);
 void    lthread_sleep(uint64_t msecs);
 void    lthread_wakeup(lthread_t *lt);
+void    lthread_renice();
 int     lthread_cond_create(lthread_cond_t **c);
 int     lthread_cond_wait(lthread_cond_t *c, uint64_t timeout);
 void    lthread_cond_signal(lthread_cond_t *c);
@@ -104,6 +105,8 @@ int     lthread_sendfile(int fd, int s, off_t offset, size_t nbytes,
 #endif
 ssize_t lthread_io_write(int fd, void *buf, size_t nbytes);
 ssize_t lthread_io_read(int fd, void *buf, size_t nbytes);
+int     lthread_is_lthread_context();
+int     lthread_is_eventfd(int fd);
 
 int lthread_compute_begin(void);
 void lthread_compute_end(void);


### PR DESCRIPTION
lthread_renice() - To allow for thread switching control from
  application code.

lthread_is_lthread_context() - When working in different thread
  contexts it can be necessary to have a way to detect if the current
  thread is running an lthread scheduler without knowing details about
  lthread internals.

lthread_is_eventfd() - This is needed on CentOS 6 to detect the
  lthread event file descriptors from application code.
