### PR TITLE
docs: fix simple typo, schduler -> scheduler

### DIFF
--- a/src/lthread_int.h
+++ b/src/lthread_int.h
@@ -134,7 +134,7 @@ struct lthread {
         int ret;
         int err;
     } io;
-    /* lthread_compute schduler - when running in compute block */
+    /* lthread_compute scheduler - when running in compute block */
     struct lthread_compute_sched    *compute_sched;
     int ready_fds; /* # of fds that are ready. for poll(2) */
     struct pollfd *pollfds;


### PR DESCRIPTION
There is a small typo in src/lthread_int.h.

Should read `scheduler` rather than `schduler`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md