### PR TITLE
modern compiler does not allow strncpy() of the same size

### DIFF
--- a/src/lthread.c
+++ b/src/lthread.c
@@ -531,7 +531,7 @@ void
 lthread_set_funcname(const char *f)
 {
     struct lthread *lt = lthread_get_sched()->current_lthread;
-    strncpy(lt->funcname, f, 64);
+    strncpy(lt->funcname, f, sizeof (lt->funcname) - 1);
 }
 
 uint64_t


### PR DESCRIPTION
modern compiler does not allow strncpy() of the same size
as the destination buffer.